### PR TITLE
Add Conjur policy to gogs and jenkins

### DIFF
--- a/conjurDemo/roles/gogsConfig/files/Conjur_Policy/Jenkinsfile
+++ b/conjurDemo/roles/gogsConfig/files/Conjur_Policy/Jenkinsfile
@@ -5,6 +5,11 @@ pipeline {
         stage ('Upload new policy') {
             steps {
                 sh "docker exec conjur-cli bash -c 'cd /Conjur_Policy && git pull && conjur policy load --replace root root.yml'"
+                sh "docker exec conjur-cli bash -c 'cd /Conjur_Policy && git pull && conjur policy load --replace jenkins jenkins.yml'"
+                sh "docker exec conjur-cli bash -c 'cd /Conjur_Policy && git pull && conjur policy load --replace tomcat tomcat.yml'"
+                sh "docker exec conjur-cli bash -c 'cd /Conjur_Policy && git pull && conjur policy load --replace webapp webapp.yml'"
+                sh "docker exec conjur-cli bash -c 'cd /Conjur_Policy && git pull && conjur policy load --replace ansible ansible.yml'"
+                sh "docker exec conjur-cli bash -c 'cd /Conjur_Policy && git pull && conjur policy load --replace secrets secrets.yml'"
             }
         }
     }

--- a/conjurDemo/roles/gogsConfig/files/Conjur_Policy/Jenkinsfile
+++ b/conjurDemo/roles/gogsConfig/files/Conjur_Policy/Jenkinsfile
@@ -1,0 +1,11 @@
+pipeline {
+    agent any
+   
+    stages {
+        stage ('Upload new policy') {
+            steps {
+                sh "docker exec conjur-cli bash -c 'cd /Conjur_Policy && git pull && conjur policy load --replace root root.yml'"
+            }
+        }
+    }
+}

--- a/conjurDemo/roles/gogsConfig/tasks/gogs.yml
+++ b/conjurDemo/roles/gogsConfig/tasks/gogs.yml
@@ -88,10 +88,11 @@
     docker exec {{ conjur_cli_container_name }} curl -s -u "{{ gogs_account }}:{{ gogs_account_password }}" -X POST -H 'Content-Type: application/json' {{ gogs_internal_url }}/api/v1/org/{{ gogs_organization }}/repos -d '{"name":"{{ item.name }}", "description":"{{ item.description }}","private":true,"auto_init":true, "gitignores":"macOS","license":"MIT License"}'
     docker exec {{ conjur_cli_container_name }} bash -c "cd / && git clone http://{{ gogs_account }}:{{ gogs_account_password }}@{{ gogs_container_name }}:{{ gogs_internal_port }}/{{ gogs_organization }}/{{ item.name }}.git"
     docker exec {{ conjur_cli_container_name }} bash -c "cp -R /policy/* /{{ item.name }}/"
+    docker cp "{{ role_path }}/files/{{ item.name }}/." "{{ conjur_cli_container_name }}:/{{ item.name }}"
     docker exec {{ conjur_cli_container_name }} bash -c "cd /{{ item.name }} && git add --all && git -c user.name={{ gogs_account }} -c user.email={{ gogs_account_email }} commit -m 'Uploading files.' && git -c user.name={{ gogs_account }} -c user.email={{ gogs_account_email }} push http://{{ gogs_account }}:{{ gogs_account_password }}@{{ gogs_container_name }}:{{ gogs_internal_port }}/{{ gogs_organization }}/{{ item.name }}.git"    
   with_items:
     - { name: 'Conjur_Policy', description: 'This is the conjur policy that is loaded.' }
-
+    
 - name: Add repositories to Team
   shell: |
     docker exec {{ conjur_cli_container_name }} curl -s -u "{{ gogs_account }}:{{ gogs_account_password }}" -X PUT "{{ gogs_internal_url }}/api/v1/admin/teams/{{ team_id.stdout }}/repos/{{ item.name }}"
@@ -105,3 +106,4 @@
     - { name: 'LAB3_AnsibleConjurLookup', description: 'This job gets a secret from Conjur.' }
     - { name: 'LAB3_AnsibleBuildContainers', description: 'This job builds containers which ansible can use as new machines.' } 
     - { name: 'LAB3_AnsibleStopContainers', description: 'This job breaks down any containers created for use with Ansible.' } 
+    - { name: 'Conjur_Policy', description: 'This is the conjur policy that is loaded.' } 

--- a/conjurDemo/roles/gogsConfig/tasks/gogs.yml
+++ b/conjurDemo/roles/gogsConfig/tasks/gogs.yml
@@ -83,6 +83,15 @@
     - { name: 'LAB3_AnsibleBuildContainers', description: 'This job builds containers which ansible can use as new machines.' } 
     - { name: 'LAB3_AnsibleStopContainers', description: 'This job breaks down any containers created for use with Ansible.' } 
 
+- name: create gogs repo for policy
+  shell: |
+    docker exec {{ conjur_cli_container_name }} curl -s -u "{{ gogs_account }}:{{ gogs_account_password }}" -X POST -H 'Content-Type: application/json' {{ gogs_internal_url }}/api/v1/org/{{ gogs_organization }}/repos -d '{"name":"{{ item.name }}", "description":"{{ item.description }}","private":true,"auto_init":true, "gitignores":"macOS","license":"MIT License"}'
+    docker exec {{ conjur_cli_container_name }} bash -c "cd / && git clone http://{{ gogs_account }}:{{ gogs_account_password }}@{{ gogs_container_name }}:{{ gogs_internal_port }}/{{ gogs_organization }}/{{ item.name }}.git"
+    docker exec {{ conjur_cli_container_name }} bash -c "cp -R /policy/* /{{ item.name }}/"
+    docker exec {{ conjur_cli_container_name }} bash -c "cd /{{ item.name }} && git add --all && git -c user.name={{ gogs_account }} -c user.email={{ gogs_account_email }} commit -m 'Uploading files.' && git -c user.name={{ gogs_account }} -c user.email={{ gogs_account_email }} push http://{{ gogs_account }}:{{ gogs_account_password }}@{{ gogs_container_name }}:{{ gogs_internal_port }}/{{ gogs_organization }}/{{ item.name }}.git"    
+  with_items:
+    - { name: 'Conjur_Policy', description: 'This is the conjur policy that is loaded.' }
+
 - name: Add repositories to Team
   shell: |
     docker exec {{ conjur_cli_container_name }} curl -s -u "{{ gogs_account }}:{{ gogs_account_password }}" -X PUT "{{ gogs_internal_url }}/api/v1/admin/teams/{{ team_id.stdout }}/repos/{{ item.name }}"

--- a/conjurDemo/roles/jenkinsConfig/files/Conjur_Policy/config.xml
+++ b/conjurDemo/roles/jenkinsConfig/files/Conjur_Policy/config.xml
@@ -1,0 +1,41 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.21">
+    <actions>
+        <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@1.2.9"/>
+        <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@1.2.9">
+            <jobProperties/>
+            <triggers/>
+            <parameters/>
+        </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
+    </actions>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty plugin="gitlab-plugin@1.5.6">
+            <gitLabConnection></gitLabConnection>
+        </com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty>
+    </properties>
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.53">
+        <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.0">
+            <configVersion>2</configVersion>
+            <userRemoteConfigs>
+                <hudson.plugins.git.UserRemoteConfig>
+                    <url>http://gogs:3000/Cyberark/Conjur_Policy.git</url>
+                    <credentialsId>gogscred</credentialsId>
+                </hudson.plugins.git.UserRemoteConfig>
+            </userRemoteConfigs>
+            <branches>
+                <hudson.plugins.git.BranchSpec>
+                    <name>*/master</name>
+                </hudson.plugins.git.BranchSpec>
+            </branches>
+            <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+            <submoduleCfg class="list"/>
+            <extensions/>
+        </scm>
+        <scriptPath>Jenkinsfile</scriptPath>
+        <lightweight>true</lightweight>
+    </definition>
+    <triggers/>
+    <disabled>false</disabled>
+</flow-definition>

--- a/conjurDemo/roles/jenkinsConfig/tasks/jenkins.yml
+++ b/conjurDemo/roles/jenkinsConfig/tasks/jenkins.yml
@@ -83,3 +83,4 @@
    - { name: 'LAB2_StopContainers', config: "{{lookup('file', 'files/LAB2_StopContainers/config.xml') }}"}
    - { name: 'LAB3_AnsibleBuildContainers', config: "{{lookup('file', 'files/LAB3_AnsibleBuildContainers/config.xml') }}"}
    - { name: 'LAB3_AnsibleStopContainers', config: "{{lookup('file', 'files/LAB3_AnsibleStopContainers/config.xml') }}"}
+   - { name: 'Conjur_Policy', config: "{{lookup('file', 'files/Conjur_Policy/config.xml') }}"}


### PR DESCRIPTION
This puts the conjur policy in gogs and adds in a jenkins job that will apply any changes to the policies in the gogs repo.