### PR TITLE
Fixes issues with the Ansible workflow

### DIFF
--- a/conjurDemo/roles/conjurConfig/files/conjur_cli_image/policy/secrets.yml
+++ b/conjurDemo/roles/conjurConfig/files/conjur_cli_image/policy/secrets.yml
@@ -106,3 +106,10 @@
    - read
    - execute
   resource: *variables
+
+- !permit
+  role: !layer /ansible/nodes
+  privileges:
+    - read
+    - execute
+  resource: *variables

--- a/conjurDemo/roles/gogsConfig/files/LAB3_AnsibleBuildContainers/files/pullpassword.sh
+++ b/conjurDemo/roles/gogsConfig/files/LAB3_AnsibleBuildContainers/files/pullpassword.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
- printf "\nGrabbing secret database password: $db_password"
+
+echo "Using Summon to grab secret database password..."
+summon sh -c "echo Done: password is \$db_password"

--- a/conjurDemo/roles/gogsConfig/files/LAB3_AnsibleBuildContainers/files/secrets.yml
+++ b/conjurDemo/roles/gogsConfig/files/LAB3_AnsibleBuildContainers/files/secrets.yml
@@ -1,1 +1,1 @@
-db_password: !var /secrets/frontend/database_password
+db_password: !var secrets/frontend/database_password

--- a/conjurDemo/roles/gogsConfig/files/LAB3_AnsibleConjurIdentity/createIdentity.yml
+++ b/conjurDemo/roles/gogsConfig/files/LAB3_AnsibleConjurIdentity/createIdentity.yml
@@ -2,7 +2,7 @@
   roles:
     - role: cyberark.conjur-host-identity
       conjur_appliance_url: 'https://conjur-master'
-      conjur_account: 'Cyberark'
+      conjur_account: 'cyberark'
       conjur_host_factory_token: ""
       conjur_host_name: "{{inventory_hostname}}"
       conjur_validate_certs: true


### PR DESCRIPTION
Currently, the Ansible workflow doesn't work as documented. I identified the following contributing issues:
1) the account listed on the Ansible node was `Cyberark` instead of `cyberark`,  this is apparently case sensitive
2) the `ansible/nodes` layer to which the Ansible host belongs wasn't granted permissions on anything in the entitlements for the `secrets/frontend/db_password` variable
3) the `secrets.yml` file asks for a secret called `/secrets/frontend/db_password` which chokes, but it likes `secrets/frontend/db_password` just fine
4) you can't just run `./pullpassword.sh` or even `summon ./pullpassword.sh`, you gotta run `summon sh ./pullpassword.sh`

These issues are resolved in this pull request and the Ansible workflow as documented in the walkthrough will complete without a hitch.