### PR TITLE
Permits gzipped archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ have one of these names:
 
 *Any other archive file(s) will be ignored.*
 
+### Use case: I have Conjur Enterprise in a local registry & don't want to mess with creating archive files
+
+In this case, you can enable Conjur Enterprise with these steps:
+1. edit `cdemo/conjurDemo/roles/conjurConfig/defaults/main.yml`
+2. change `conjur_version` to `EE`
+3. change `conjur_EE_image_name` to the fully qualified name of the Conjur
+   Enterprise appliance image in your local registry. (by default this refers to
+   its name in CyberArk's local registry, so if you're a CyberArk employee you
+   don't have to do anything.)
+
+Now cdemo will use Conjur Enterprise without requiring an archive file.
+
 ## Conjur CLI information
 
 The Conjur CLI will be pre-configured to work with the Conjur container. Inside

--- a/README.md
+++ b/README.md
@@ -33,9 +33,38 @@ The demo uses the lastest version of Conjur v5
     * Conjur alone can be configured by running sudo ansible-playbook -i inventory.yml conjurSetup.yml
     * Ansible with PAS jobs can be deployed by setting the variable "ansible_pas: 'YES'" in site.yml
 
+## Using cdemo with Conjur Enterprise
+
+By default, cdemo will build with Conjur Open Source which is available to
+everyone as LGPL software. However, if you have access to Conjur Enterprise,
+cdemo can use that instead.
+
+In order to enable Conjur Enterprise, you need an archive containing the Conjur
+Enterprise appliance image in the root directory of cdemo (same as this readme.)
+
+If you have access to a Docker registry containing Conjur Enterprise you can
+create the acrhive yourself like so:
+
+```sh-session
+$ docker image save registry.local/conjur-appliance:5.0-stable | gzip -c >conjur.tgz
+```
+
+If you don't have access, you can download the archive file from your CyberArk
+support vault or contact CyberArk sales to get access. After downloading the
+arcvhive file, move it to this folder.
+
+Note: in order to be recognized as a Conjur Enterprise archive file, it must
+have one of these names:
+* `conjur.tar`
+* `conjur.tar.gz`
+* `conjur.tgz`
+
+*Any other archive file(s) will be ignored.*
+
 ## Conjur CLI information
 
-The cli has been configured to work with the Conjur container.  It has the scripts folder mapped to /scripts.
+The Conjur CLI will be pre-configured to work with the Conjur container. Inside
+the CLI container, the scripts folder is mounted to `/scripts`.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,7 @@ In this case, you can enable Conjur Enterprise with these steps:
 1. edit `cdemo/conjurDemo/roles/conjurConfig/defaults/main.yml`
 2. change `conjur_version` to `EE`
 3. change `conjur_EE_image_name` to the fully qualified name of the Conjur
-   Enterprise appliance image in your local registry. (by default this refers to
-   its name in CyberArk's local registry, so if you're a CyberArk employee you
-   don't have to do anything.)
+   Enterprise appliance image in your local registry.
 
 Now cdemo will use Conjur Enterprise without requiring an archive file.
 

--- a/conjurDemo/roles/awxConfig/defaults/main.yml
+++ b/conjurDemo/roles/awxConfig/defaults/main.yml
@@ -16,7 +16,6 @@ docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker
 # defaults file for conjurConfig
 conjur_version: 'OSS'
 conjur_container_name: 'conjur-master'
-conjur_EE_image_name: 'registry2.itci.conjur.net/conjur-appliance:5.0-stable'
 conjur_network_name: conjur
 conjur_https_port: '443'
 conjur_cli_container_name: 'conjur-cli'

--- a/conjurDemo/roles/conjurConfig/defaults/main.yml
+++ b/conjurDemo/roles/conjurConfig/defaults/main.yml
@@ -16,7 +16,7 @@ docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker
 # defaults file for conjurConfig
 conjur_version: 'OSS'
 conjur_container_name: 'conjur-master'
-conjur_EE_image_name: 'registry2.itci.conjur.net/conjur-appliance:5.0-stable'
+conjur_EE_image_name: 'conjur-appliance'
 conjur_network_name: conjur
 conjur_https_port: '443'
 conjur_cli_container_name: 'conjur-cli'

--- a/conjurDemo/roles/conjurConfig/tasks/conjurEE.yml
+++ b/conjurDemo/roles/conjurConfig/tasks/conjurEE.yml
@@ -6,7 +6,24 @@
   with_items:
    - "{{ conjur_audit_volume }}"
 
-- name: Start conjur container
+- name: Load Conjur appliance image from archive
+  docker_image:
+    name: "{{ conjur_EE_image_name }}"
+    load_path: "{{ conjur_tar_path }}"
+    state: present
+    timeout: 120
+
+- name: Get facts of loaded images
+  docker_image_facts:
+  register: loaded
+
+- name: Get full name of conjur-appliance image
+  set_fact:
+    conjur_EE_image_name: "{{ item }}"
+  with_items: "{{ loaded.images | json_query('[].RepoTags[0]') }}"
+  when: ('conjur-appliance' in item)
+
+- name: Start Conjur appliance
   docker_container:
     name: "{{ conjur_container_name }}"
     image: "{{ conjur_EE_image_name }}"
@@ -21,11 +38,11 @@
      - "{{ conjur_audit_volume }}:{{ conjur_audit_directory }}"
     restart_policy: always
 
-- name: configure conjur container
+- name: Configure Conjur container
   shell: |
     docker exec {{ conjur_container_name }} evoke configure master -h {{ conjur_container_name }} -p {{ conjur_admin_password }} {{ conjur_account }}
 
-- name: configure cli for EE
+- name: Configure CLI for EE
   shell: |
     docker exec {{ conjur_cli_container_name }} bash -c "conjur init -u https://{{ conjur_container_name }} -a {{ conjur_account }} <<< yes"
     docker exec {{ conjur_cli_container_name }} conjur authn login -u admin -p {{ conjur_admin_password }}

--- a/conjurDemo/roles/conjurConfig/tasks/main.yml
+++ b/conjurDemo/roles/conjurConfig/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Check for conjur registry access
-  shell: |
-    cat ~/.docker/config.json
-  ignore_errors: yes
-  register: conjurRegistry
 
 - name: Check for conjur.tar
   stat:
@@ -27,7 +22,7 @@
     load_path: "{{ conjur_tar_path }}"
     state: present
     timeout: 120
-  when: (conjurRegistry.stdout.find('registry2.itci.conjur.net') == -1) and conjur_version == 'EE'
+  when: conjur_version == 'EE'
 
 - include_tasks: conjurCLI.yml
 

--- a/conjurDemo/roles/conjurConfig/tasks/main.yml
+++ b/conjurDemo/roles/conjurConfig/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Load Conjur tar
   docker_image:
-    name: conjur-appliance
+    name: "{{ conjur_EE_image_name }}"
     load_path: "{{ conjur_tar_path }}"
     state: present
     timeout: 120

--- a/conjurDemo/roles/conjurConfig/tasks/main.yml
+++ b/conjurDemo/roles/conjurConfig/tasks/main.yml
@@ -7,26 +7,32 @@
 
 - name: Check for conjur.tar
   stat:
-     path: ../conjur.tar
+     path: ../conjur.{{item}}
+  with_items:
+    - "tar"
+    - "tar.gz"
+    - "tgz"
   register: conjurTar
 
-- name: Set varilables
+- name: Inform about Enterprise availability
   set_fact:
     conjur_version: 'EE'
-  when: conjurTar.stat.exists == True
-  
+    conjur_tar_path: "{{ item.stat.path }}"
+  when: item.stat.exists
+  with_items: "{{ conjurTar.results }}"
+
 - name: Load Conjur tar
   docker_image:
     name: conjur-appliance
-    load_path: ../conjur.tar
+    load_path: "{{ conjur_tar_path }}"
     state: present
     timeout: 120
-  when: (conjurRegistry.stdout.find('registry2.itci.conjur.net') == -1) and (conjurTar.stat.exists == True)
+  when: (conjurRegistry.stdout.find('registry2.itci.conjur.net') == -1) and conjur_version == 'EE'
 
 - include_tasks: conjurCLI.yml
 
 - include_tasks: conjurOSS.yml
-  when: ((conjurTar.stat.exists == False and (conjurRegistry.stdout.find('registry2.itci.conjur.net') == -1)) or conjur_version == 'OSS')
+  when: conjur_version == 'OSS'
 
 - include_tasks: conjurEE.yml
-  when: ((conjurRegistry.stdout.find('registry2.itci.conjur.net') != -1) or (conjurTar.stat.exists == True)) and conjur_version == 'EE'
+  when: conjur_version == 'EE'

--- a/conjurDemo/roles/conjurConfig/tasks/main.yml
+++ b/conjurDemo/roles/conjurConfig/tasks/main.yml
@@ -16,14 +16,6 @@
   when: item.stat.exists
   with_items: "{{ conjurTar.results }}"
 
-- name: Load Conjur tar
-  docker_image:
-    name: "{{ conjur_EE_image_name }}"
-    load_path: "{{ conjur_tar_path }}"
-    state: present
-    timeout: 120
-  when: conjur_version == 'EE'
-
 - include_tasks: conjurCLI.yml
 
 - include_tasks: conjurOSS.yml

--- a/conjurDemo/roles/dockerConfig/defaults/main.yml
+++ b/conjurDemo/roles/dockerConfig/defaults/main.yml
@@ -16,7 +16,6 @@ docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker
 # defaults file for conjurConfig
 conjur_version: 'OSS'
 conjur_container_name: 'conjur-master'
-conjur_EE_image_name: 'registry2.itci.conjur.net/conjur-appliance:5.0-stable'
 conjur_network_name: conjur
 conjur_https_port: '443'
 conjur_cli_container_name: 'conjur-cli'

--- a/conjurDemo/roles/gogsConfig/defaults/main.yml
+++ b/conjurDemo/roles/gogsConfig/defaults/main.yml
@@ -16,7 +16,6 @@ docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker
 # defaults file for conjurConfig
 conjur_version: 'OSS'
 conjur_container_name: 'conjur-master'
-conjur_EE_image_name: 'registry2.itci.conjur.net/conjur-appliance:5.0-stable'
 conjur_network_name: conjur
 conjur_https_port: '443'
 conjur_cli_container_name: 'conjur-cli'

--- a/conjurDemo/roles/jenkinsConfig/defaults/main.yml
+++ b/conjurDemo/roles/jenkinsConfig/defaults/main.yml
@@ -16,7 +16,6 @@ docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker
 # defaults file for conjurConfig
 conjur_version: 'OSS'
 conjur_container_name: 'conjur-master'
-conjur_EE_image_name: 'registry2.itci.conjur.net/conjur-appliance:5.0-stable'
 conjur_network_name: conjur
 conjur_https_port: '443'
 conjur_cli_container_name: 'conjur-cli'

--- a/conjurDemo/roles/machinePrep/defaults/main.yml
+++ b/conjurDemo/roles/machinePrep/defaults/main.yml
@@ -16,7 +16,6 @@ docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker
 # defaults file for conjurConfig
 conjur_version: 'OSS'
 conjur_container_name: 'conjur-master'
-conjur_EE_image_name: 'registry2.itci.conjur.net/conjur-appliance:5.0-stable'
 conjur_network_name: conjur
 conjur_https_port: '443'
 conjur_cli_container_name: 'conjur-cli'

--- a/conjurDemo/roles/splunk/defaults/main.yml
+++ b/conjurDemo/roles/splunk/defaults/main.yml
@@ -16,7 +16,6 @@ docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker
 # defaults file for conjurConfig
 conjur_version: 'OSS'
 conjur_container_name: 'conjur-master'
-conjur_EE_image_name: 'registry2.itci.conjur.net/conjur-appliance:5.0-stable'
 conjur_network_name: conjur
 conjur_https_port: '443'
 conjur_cli_container_name: 'conjur-cli'

--- a/conjurDemo/roles/weavescopeConfig/defaults/main.yml
+++ b/conjurDemo/roles/weavescopeConfig/defaults/main.yml
@@ -16,7 +16,6 @@ docker_apt_repository: "deb [arch={{ docker_apt_arch }}] https://download.docker
 # defaults file for conjurConfig
 conjur_version: 'OSS'
 conjur_container_name: 'conjur-master'
-conjur_EE_image_name: 'registry2.itci.conjur.net/conjur-appliance:5.0-stable'
 conjur_network_name: conjur
 conjur_https_port: '443'
 conjur_cli_container_name: 'conjur-cli'


### PR DESCRIPTION
This change allows the cdemo operator to use a gzipped archive of a Conjur Enterprise docker image in addition to an uncompressed archive.

More details are in README.md under the heading "Using cdemo with Conjur Enterprise"