### PR TITLE
Adds script to check network connectivity before installation

### DIFF
--- a/bin/check-network
+++ b/bin/check-network
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -u
+
+function check() {
+    local url="$1"
+    echo -n "  $url... "
+    curl -sSf "$url" >/dev/null
+    if [[ $? == 0 ]]; then
+        echo "✓"
+        return 0
+    else
+        return 1
+    fi
+}
+
+URLs=(
+    'https://hub.docker.com'
+    'https://github.com'
+    'https://plugins.jenkins.io'
+)
+
+echo "Checking network connectivity:"
+
+total=0
+for url in "${URLs[@]}"; do
+    check "$url"
+    total="$((($total + $?)))"
+done
+
+if [[ $total > 0 ]]; then
+    echo "❌ connectivity insufficient to install cdemo ❌"
+    exit 1
+else
+    exit 0
+fi

--- a/installAnsible.sh
+++ b/installAnsible.sh
@@ -1,42 +1,52 @@
 #!/bin/bash
 
-main(){
-  printf '\n-----'
-  printf '\nInstalling dependencies'
-  if [[ $(cat /etc/*-release | grep -w ID_LIKE) == 'ID_LIKE="rhel fedora"' ]]; then
+set -eu
+
+function separator() {
+    echo "-----"
+}
+
+function install_ansible_yum() {
+    echo "Updating yum"
+    sudo yum update -y &> /dev/null
+    echo "Upgrading system"
+    sudo yum upgrade -y &> /dev/null
+    echo "Installing EPEL repo"
+    sudo yum install epel-release -y &> /dev/null
+    echo "Updating Repolist"
+    sudo yum repolist &> /dev/null
+    sudo yum update -y &> /dev/null
+    echo "Installing Ansible"
+    sudo yum install ansible -y &> /dev/null
+}
+
+function install_ansible_apt() {
+    echo "Installing dirmngr"
+    sudo apt-get install dirmngr
+    echo "Installing source repo"
+    echo 'deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main' >> /etc/apt/sources.list
+    echo "Installing keyserver"
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+    echo "Updating APT"
+    sudo apt-get update -y
+    echo "Installing Ansible"
+    sudo apt-get install ansible -y
+}
+
+bin/check-network
+separator
+echo 'Installing dependencies'
+if [[ $(cat /etc/*-release | grep -w ID_LIKE) == 'ID_LIKE="rhel fedora"' ]]; then
     install_ansible_yum
-  elif [[ $(cat /etc/*-release | grep -w ID) == 'ID=debian' ]]; then
+elif [[ $(cat /etc/*-release | grep -w ID) == 'ID=debian' ]]; then
     install_ansible_apt
-  else
-    printf "\nCouldn't figure out OS"
-  fi
-  printf '\n-----\n'
-}
-
-install_ansible_yum(){
-  printf '\nUpdating yum\n'
-  sudo yum update -y &> /dev/null
-  printf '\nUpgrading system\n'
-  sudo yum upgrade -y &> /dev/null
-  printf '\nInstalling EPEL repo\n'
-  sudo yum install epel-release -y &> /dev/null
-  printf '\nUpdating Repolist\n'
-  sudo yum repolist &> /dev/null
-  sudo yum update -y &> /dev/null
-  printf '\nInstalling Ansible\n'
-  sudo yum install ansible -y &> /dev/null
-}
-
-install_ansible_apt(){
-  printf "\nInstalling dirmngr"
-  sudo apt-get install dirmngr
-  printf "\nInstalling source repo"
-  echo 'deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main' >> /etc/apt/sources.list
-  printf "\nInstalling keyserver"
-  sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-  printf "\nUpdating APT"
-  sudo apt-get update -y
-  printf "\nInstalling Ansible"
-  sudo apt-get install ansible -y
-}
-main
+else
+    echo "This script cannot install Ansible automatically"
+    echo "on your operating system. Please figure out how to"
+    echo "do so, then submit a patch to add support."
+    echo "Thank you!"
+    echo "-maintainer"
+    echo "https://github.com/conjurdemos/cdemo/blob/master/installAnsible.sh"
+fi
+separator
+printf "\n"


### PR DESCRIPTION
#### What does this PR do?

It checks for internet connectivity before installing Ansible. Specifically, it checks these URLs:
* hub.docker.com
* github.com
* plugins.jenkins.io

#### What is the background?

We've occasionally had reports of failure to install cdemo which were ultimately traced to basic network connectivity problems, eg with NATs and firewalls and so on blocking access to necessary domains.

In order to make it clear up front where the failure is and what the expectations are, this script prints out in plain language whether it's able to connect.

#### How should the reviewer test this?

The lazy way is to checkout the `network-check` branch and run `bin/check-network`. That will run the network check alone and nothing else.

The more methodical way is:
* checkout the `network-check` branch in your cdemo VM
* turn off network access to your VM
* run `installAnsible.sh`
  
  this should FAIL IMMEDIATELY with warnings about connectivity
* turn network access back on
* run `installAnsible.sh`
  
  this should succeed as usual

#### Example sessions

Good connectivity:
```
$ ./installAnsible.sh 
Checking network connectivity:
  https://hub.docker.com... ✓
  https://github.com... ✓
  https://plugins.jenkins.io... ✓
-----
Installing dependencies
[...]
```

Bad connectivity:
```
$ ./installAnsible.sh 
Checking network connectivity:
  https://hub.docker.com... curl: (6) Could not resolve host: hub.docker.com
  https://github.com... curl: (6) Could not resolve host: github.com
  https://plugins.jenkins.io... curl: (6) Could not resolve host: plugins.jenkins.io
❌ connectivity insufficient to install cdemo ❌
```