### PR TITLE
Uses persistent (& configurable) data directory for AWX postgres DB

### DIFF
--- a/conjurDemo/roles/awxConfig/defaults/main.yml
+++ b/conjurDemo/roles/awxConfig/defaults/main.yml
@@ -70,6 +70,7 @@ ansible_password: 'Cyberark1'
 ansible_user: "{{ conjur_devops_admin_account }}"
 ansible_organization: 'Cyberark'
 ansible_pas: 'NO'
+ansible_awx_data_dir: '/ansible/pgdocker'
 
 # defaults file for splunk
 splunk_install: 'NO'

--- a/conjurDemo/roles/awxConfig/tasks/main.yml
+++ b/conjurDemo/roles/awxConfig/tasks/main.yml
@@ -3,6 +3,7 @@
   git:
     dest: /opt/awx
     clone: yes
+    force: yes
     repo: https://github.com/ansible/awx.git
   when: ansible_install == 'YES'
 

--- a/conjurDemo/roles/awxConfig/tasks/main.yml
+++ b/conjurDemo/roles/awxConfig/tasks/main.yml
@@ -12,6 +12,8 @@
     sed -i "s,host_port=80,host_port={{ ansible_port }},g" ./inventory
     sed -i "s,.*default_admin_password=.*,default_admin_password={{ ansible_password }},g" ./inventory
     sed -i "s,# default_admin_user=admin,default_admin_user={{ ansible_user }},g" ./inventory
+    mkdir -p "{{ ansible_awx_data_dir }}"
+    sed -i "s,#? *postgres_data_dir=/tmp/pgdocker,postgres_data_dir={{ ansible_awx_data_dir }},g" ./inventory
   when: ansible_install == 'YES'
 
 - name: start up awx


### PR DESCRIPTION
#### What does this PR do?

It configures AWX on install to use a persistent data directory. This is given by the variable `ansible_awx_data_dir`, with a default value of `/ansible/pgdocker`.

#### What's the background behind this change?

By default, Ansible AWX uses a folder in `/tmp` to store its Postgres data. This means it can be wiped out after an upgrade. By changing the default to a directory outside of `/tmp`, we make the database more durable.

#### How to test?

* check out the `awx-use-persistent-data-directory` branch
* install cdemo with AWX (which is default, so just don't disable it)
* manually upgrade AWX
* verify that the expected job data is still present