### PR TITLE
Add EULA acceptance to evoke configure master

### DIFF
--- a/conjurDemo/roles/conjurConfig/tasks/conjurEE.yml
+++ b/conjurDemo/roles/conjurConfig/tasks/conjurEE.yml
@@ -41,6 +41,8 @@
   shell: |
     docker exec {{ conjur_container_name }} \
       evoke configure master \
+        $(docker exec {{ conjur_container_name }} evoke configure master --help | \
+          grep -q accept-eula && echo "--accept-eula") \
         -h {{ conjur_container_name }} \
         -p {{ conjur_admin_password }} \
         {{ conjur_account }}


### PR DESCRIPTION
This PR updates the Ansible playbook for configuring the DAP master to include the `--accept-eula` flag when it detects that the evoke version accepts it (based on the command options in `evoke configure master --help`).