### PR TITLE
Handle the cdemo PS upgrade to 9.4.

### DIFF
--- a/conjurDemo/roles/conjurConfig/tasks/conjurOSS.yml
+++ b/conjurDemo/roles/conjurConfig/tasks/conjurOSS.yml
@@ -2,7 +2,7 @@
 - name: Start postgres
   docker_container:
     name: database
-    image: postgres:9.3
+    image: postgres:9.4
     state: started
     recreate: yes
     networks:


### PR DESCRIPTION
It is a prerequisite for the audit atomicity.
New data type JsonB was introduced in PS9.4 and is used by the audit.